### PR TITLE
Fix code scanning alert no. 8: Database query built from user-controlled sources

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -77,7 +77,7 @@ client
         const currentTime = new Date();
 
         const result = await subjects.updateOne(
-          { name },
+          { name: { $eq: name } },
           {
             $inc: { attended: 1, total: 1 },
             $set: { lastUpdated: currentTime }
@@ -102,7 +102,7 @@ client
         const currentTime = new Date();
 
         const result = await subjects.updateOne(
-          { name },
+          { name: { $eq: name } },
           {
             $inc: { missed: 1, total: 1 },
             $set: { lastUpdated: currentTime }


### PR DESCRIPTION
Fixes [https://github.com/akshay-mathad/attendance-tracker/security/code-scanning/8](https://github.com/akshay-mathad/attendance-tracker/security/code-scanning/8)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will prevent any potential NoSQL injection attacks by ensuring that the `name` parameter is treated as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
