### PR TITLE
Fix code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -77,7 +77,7 @@ client
         const currentTime = new Date();
 
         const result = await subjects.updateOne(
-          { name },
+          { name: { $eq: name } },
           {
             $inc: { attended: 1, total: 1 },
             $set: { lastUpdated: currentTime }


### PR DESCRIPTION
Fixes [https://github.com/akshay-mathad/attendance-tracker/security/code-scanning/7](https://github.com/akshay-mathad/attendance-tracker/security/code-scanning/7)

To fix the problem, we need to ensure that the user input is sanitized or validated before it is used in the MongoDB query. The best way to do this is by using the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This approach prevents NoSQL injection attacks by treating the user input as a simple value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
